### PR TITLE
feat: Add support to skip users

### DIFF
--- a/src/server/controllers/banner.js
+++ b/src/server/controllers/banner.js
@@ -18,8 +18,10 @@ export default async function banner(req, res) {
   const showBtn = parseToBooleanDefaultTrue(req.query.button);
 
   let skipUsers = [];
-  if (req.query.skip) {
+  if (typeof req.query.skip === 'string') {
     skipUsers = req.query.skip.split(',');
+  } else if (Array.isArray(req.query.skip)) {
+    skipUsers = req.query.skip;
   }
 
   let contributors;

--- a/src/server/controllers/banner.js
+++ b/src/server/controllers/banner.js
@@ -14,8 +14,14 @@ export default async function banner(req, res) {
   const limit = Number(req.query.limit) || Infinity;
   const width = Number(req.query.width) || 0;
   const height = Number(req.query.height) || 0;
+  const skip = req.query.skip;
   const { avatarHeight, margin } = req.query;
   const showBtn = parseToBooleanDefaultTrue(req.query.button);
+
+  let skipUsers = skip || [];
+  if (!Array.isArray(skipUsers)) {
+    skipUsers = [skip];
+  }
 
   let contributors;
   try {
@@ -37,14 +43,16 @@ export default async function banner(req, res) {
     return res.status(code).send(message);
   }
 
-  contributors = Object.keys(contributors).map((username) => {
-    return {
-      slug: username,
-      type: 'GITHUB_USER',
-      image: `https://avatars.githubusercontent.com/${username}?s=96`,
-      website: `https://github.com/${username}`,
-    };
-  });
+  contributors = Object.keys(contributors)
+    .filter((username) => !skipUsers.includes(username))
+    .map((username) => {
+      return {
+        slug: username,
+        type: 'GITHUB_USER',
+        image: `https://avatars.githubusercontent.com/${username}?s=96`,
+        website: `https://github.com/${username}`,
+      };
+    });
 
   let buttonImage;
   if (showBtn) {

--- a/src/server/controllers/banner.js
+++ b/src/server/controllers/banner.js
@@ -14,13 +14,12 @@ export default async function banner(req, res) {
   const limit = Number(req.query.limit) || Infinity;
   const width = Number(req.query.width) || 0;
   const height = Number(req.query.height) || 0;
-  const skip = req.query.skip;
   const { avatarHeight, margin } = req.query;
   const showBtn = parseToBooleanDefaultTrue(req.query.button);
 
-  let skipUsers = skip || [];
-  if (!Array.isArray(skipUsers)) {
-    skipUsers = [skip];
+  let skipUsers = [];
+  if (req.query.skip) {
+    skipUsers = req.query.skip.split(',');
   }
 
   let contributors;

--- a/src/server/lib/contributors.js
+++ b/src/server/lib/contributors.js
@@ -32,13 +32,18 @@ export async function fetchContributors({ collectiveSlug }) {
   // Fetch data from Open Collective API
   const query = gql`
     query GithubContributors($collectiveSlug: String) {
-      Collective(slug: $collectiveSlug) {
+      collective(slug: $collectiveSlug) {
         id
         name
         slug
         githubHandle
         settings
-        githubContributors
+        contributors {
+          nodes {
+            id
+            name
+          }
+        }
       }
     }
   `;
@@ -47,7 +52,7 @@ export async function fetchContributors({ collectiveSlug }) {
 
   // Trigger Update
   logger.info(`Triggering contributors update for '${collectiveSlug}'`);
-  updateContributors(result.Collective);
+  updateContributors(result.collective);
 
   // Try 30 times in 10 seconds to check if the data arrived
   let iteration = 1;
@@ -63,9 +68,9 @@ export async function fetchContributors({ collectiveSlug }) {
   }
 
   // Fallback with results from Open Collective API
-  if (result.Collective.githubContributors && Object.keys(result.Collective.githubContributors).length > 0) {
+  if (result.collective.contributors && Object.keys(result.collective.contributors).length > 0) {
     logger.warn(`Not available. Using fallback for collective '${collectiveSlug}'`);
-    return result.Collective.githubContributors;
+    return result.collective.contributors;
   }
 
   throw new Error(`Not available. Fetching contributors for collective '${collectiveSlug}'`);

--- a/src/server/lib/contributors.js
+++ b/src/server/lib/contributors.js
@@ -32,18 +32,13 @@ export async function fetchContributors({ collectiveSlug }) {
   // Fetch data from Open Collective API
   const query = gql`
     query GithubContributors($collectiveSlug: String) {
-      collective(slug: $collectiveSlug) {
+      Collective(slug: $collectiveSlug) {
         id
         name
         slug
         githubHandle
         settings
-        contributors {
-          nodes {
-            id
-            name
-          }
-        }
+        githubContributors
       }
     }
   `;
@@ -52,7 +47,7 @@ export async function fetchContributors({ collectiveSlug }) {
 
   // Trigger Update
   logger.info(`Triggering contributors update for '${collectiveSlug}'`);
-  updateContributors(result.collective);
+  updateContributors(result.Collective);
 
   // Try 30 times in 10 seconds to check if the data arrived
   let iteration = 1;
@@ -68,9 +63,9 @@ export async function fetchContributors({ collectiveSlug }) {
   }
 
   // Fallback with results from Open Collective API
-  if (result.collective.contributors && Object.keys(result.collective.contributors).length > 0) {
+  if (result.Collective.githubContributors && Object.keys(result.Collective.githubContributors).length > 0) {
     logger.warn(`Not available. Using fallback for collective '${collectiveSlug}'`);
-    return result.collective.contributors;
+    return result.Collective.githubContributors;
   }
 
   throw new Error(`Not available. Fetching contributors for collective '${collectiveSlug}'`);


### PR DESCRIPTION
Add a new query parameter `skip` that can be specified multiple times to skip specific users. Can be used to filter out bots or other users that don't want to be a part of the contributors list.